### PR TITLE
handle 0 or negative DashPatterns

### DIFF
--- a/AddMaterials/View/Controls/FillPatternViewerControlWpf.xaml.cs
+++ b/AddMaterials/View/Controls/FillPatternViewerControlWpf.xaml.cs
@@ -225,7 +225,7 @@ namespace AddMaterials.View.Controls
           if( segments.Count > 0 )
           {
             pen.DashPattern = segments
-              .Select( Convert.ToSingle )
+              .Select(s => Math.Max(float.Epsilon, Convert.ToSingle(s)) )
               .ToArray();
 
             Debug.Print( "\tSegments:" );


### PR DESCRIPTION
We are using similar code in a project of ours, and we ran into an issue where some fill patterns had blank preview images. Some of the patterns had very small negative values (such as `-5.9211894646675012E-16`), and `DashPattern`s must be greater than 0. Using `float.Epsilon` produces previews that actually look correct.

_Example preview we got by filtering out segments that were <= 0_
![Third Bond - Emporer Brick - partial fix](https://user-images.githubusercontent.com/744206/59060167-5b7c9600-8855-11e9-8bee-615fb8cf9f85.png)

_Example using the fix in this PR, using float.Epsilon_
![Third Bond - Emporer Brick - fixed](https://user-images.githubusercontent.com/744206/59060166-5ae3ff80-8855-11e9-803f-5566ac8e7780.png)


